### PR TITLE
Change translation of `fork` builtin

### DIFF
--- a/lib/translate_aneris.ml
+++ b/lib/translate_aneris.ml
@@ -136,8 +136,8 @@ let node_from_builtin s args = match s, args with
      Substring (expr1, expr2, expr3)
   | "FindFrom", [expr1; expr2; expr3] ->
      FindFrom (expr1, expr2, expr3)
-  | "Fork", [expr] ->
-     Fork expr
+  | "Fork", [f; e] ->
+     Fork (App (f, e))
   | "RefLbl", [Var (Vlvar expr1); expr2] ->
      Alloc ((Some expr1), expr2)
   | "RefLbl", [Val (LitV LitString s); expr2] ->


### PR DESCRIPTION
Fork is lazy in AnerisLang, but strict in Ocaml.
So we want `fork f e` in Ocaml to become `fork (f e)`.