### PR TITLE
Ensure that `ignore` is translated with unit return type

### DIFF
--- a/lib/translate_aneris.ml
+++ b/lib/translate_aneris.ml
@@ -622,7 +622,9 @@ and expression info expr =
   | Pexp_fun _ ->
      assert false (* TODO *)
   | Pexp_apply (f, [(_, e)]) when is_ignore f ->
-     expression info e
+     let expr1 = expression info e in
+     let expr2 = Val (LitV LitUnit) in
+     App (mk_lamb BAnon expr2, expr1)
   | Pexp_apply (f, [(_, e)]) when is_fst f ->
      Fst (expression info e)
   | Pexp_apply (f, [(_, e)]) when is_snd f ->


### PR DESCRIPTION
`AnerisLang` is untyped, but it's still important that we return `unit` since it shows up in the specs and proofs.